### PR TITLE
KeyError from missing CpGs in example code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/*
+.ipynb_checkpoints/*

--- a/example.ipynb
+++ b/example.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 28,
    "id": "incorporated-kelly",
    "metadata": {},
    "outputs": [],
@@ -24,13 +24,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 29,
    "id": "83b420f2-2fbd-4d67-a540-33815011d956",
    "metadata": {},
    "outputs": [],
    "source": [
     "#load list of selected CpGsites\n",
-    "cpgs = np.array(pd.read_pickle('example_dependencies/multi_platform_cpgs.pkl'))\n",
+    "AltumAge_cpgs = np.array(pd.read_pickle('example_dependencies/multi_platform_cpgs.pkl'))\n",
     "\n",
     "#load processed example data from GEO30870 data set\n",
     "#ensure the methylation data has been normalized with BMIQCalibration from Horvath 2013\n",
@@ -40,24 +40,24 @@
     "scaler = pd.read_pickle('example_dependencies/scaler.pkl')\n",
     "\n",
     "#load AltumAge model\n",
-    "AltumAge = tf.keras.models.load_model('AltumAge.h5')"
+    "AltumAge = tf.keras.models.load_model('example_dependencies/AltumAge.h5')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 30,
    "id": "humanitarian-invitation",
    "metadata": {},
    "outputs": [],
    "source": [
     "#regardless of the Illumina platform, select *in order* the 20318 CpG sites from the list \n",
     "real_age = data.age\n",
-    "methylation_data = data[cpgs]"
+    "methylation_data = data[AltumAge_cpgs]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 31,
    "id": "collective-proxy",
    "metadata": {},
    "outputs": [],
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 32,
    "id": "colored-colonial",
    "metadata": {},
    "outputs": [],
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 33,
    "id": "figured-benchmark",
    "metadata": {},
    "outputs": [
@@ -87,9 +87,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The Median Absolute Error is: 9.992599487304688\n",
-      "The Mean Squared Error is: 98.52498424905616\n",
-      "Pearson's Correlation Coefficient is: 0.9890003381511906\n"
+      "The Median Absolute Error is: 9.992607116699219\n",
+      "The Mean Squared Error is: 98.52502890899538\n",
+      "Pearson's Correlation Coefficient is: 0.9890003295203428\n"
      ]
     }
    ],
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 34,
    "id": "generous-completion",
    "metadata": {},
    "outputs": [],
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 35,
    "id": "present-religious",
    "metadata": {},
    "outputs": [],
@@ -154,18 +154,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 36,
+   "id": "10a0436d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# horvath_cpgs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
    "id": "spoken-paragraph",
    "metadata": {},
    "outputs": [],
    "source": [
     "#predict with Horvath's 2013 model\n",
-    "pred_ages_Horvath = anti_transform_age(horvath_model.predict(methylation_data[horvath_cpgs]))"
+    "pred_ages_Horvath = anti_transform_age(horvath_model.predict(data[horvath_cpgs]))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 38,
    "id": "engaging-proxy",
    "metadata": {},
    "outputs": [
@@ -173,9 +183,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The Median Absolute Error is: 14.140236344179442\n",
-      "The Mean Squared Error is: 171.92677509854326\n",
-      "Pearson's Correlation Coefficient is: 0.9726306089777842\n"
+      "The Median Absolute Error is: 14.140236344179392\n",
+      "The Mean Squared Error is: 171.92677509854278\n",
+      "Pearson's Correlation Coefficient is: 0.9726306089777844\n"
      ]
     }
    ],
@@ -188,6 +198,14 @@
     "print('The Mean Squared Error is: ' + str(mse))\n",
     "print(\"Pearson's Correlation Coefficient is: \" + str(r))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ea90dc0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -206,7 +224,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi! 

I fixed 2 small bugs in example.ipynb: 
1 - Path error to .h5 file
2 - Some Horvath CpGs were dropped from the dataframe before running inference for AltumAge

Regarding 2) I got a KeyError error on the line that call's Horvath's model. It seems the following CpGs were not in the dataframe: ['cg02654291', 'cg02972551', 'cg09785172', 'cg09869858', 'cg13682722', 'cg16494477', 'cg17408647', 'cg19273182', 'cg19945840', 'cg27319898', 'cg04431054', 'cg05590257', 'cg06117855', 'cg19046959', 'cg19569684', 'cg24471894', 'cg27016307'].

![Screen Shot 2021-09-05 at 12 15 28 PM](https://user-images.githubusercontent.com/11399570/132133839-0bc0bb16-ffc4-4ed8-916f-9a255a87d668.png)

I've also added a .gitignore file which is standard practice to avoid committing undesirable files (i.e. notebook checkpoints, virtual env contents, etc...)